### PR TITLE
repr temp & cli attack fix

### DIFF
--- a/lib/cli.py
+++ b/lib/cli.py
@@ -82,6 +82,8 @@ def main():
 
                 elif choice == "2":
                     print(player)
+                    print(f"{player_username}, your current hitpoints are: {player.hit_points}")
+
 
                 elif choice == "3" and current_monster.has_healing_item and not current_monster.healing_item_used:
                     healing_amount = 30

--- a/lib/models/player.py
+++ b/lib/models/player.py
@@ -14,11 +14,11 @@ class Player:
     def __repr__(self):
         return f"{self.username} (HP: {self.hit_points})"
 
-    def __repr__(self):
-        return (
-            f"<Player {self.id}: {self.username}, "
-            f"Email: {self.email}>"
-        )
+    # def __repr__(self):
+    #     return (
+    #         f"<Player {self.id}: {self.username}, "
+    #         f"Email: {self.email}>"
+    #     )
 
     @property
     def username(self):


### PR DESCRIPTION
### Changes
Fixes CLI to display user's HP again and removes one of the `repr` statements - we can change display later